### PR TITLE
Add multiapp support

### DIFF
--- a/autoupdate.py
+++ b/autoupdate.py
@@ -23,7 +23,7 @@ logging.addLevelName(logging.WARNING, "%s%s%s" % (CWARN, logging.getLevelName(lo
 logging.addLevelName(logging.ERROR, "%s%s%s" % (CWARN, logging.getLevelName(logging.ERROR), CRESET))
 
 
-def outputError(cmd, output):
+def output_error(cmd, output):
     logging.warning("{}{}{}{} command failed!{}".format(CBOLD, cmd, CRESET, CWARN, CRESET))
     logging.info("See the following output:")
     logging.info(output)
@@ -82,7 +82,7 @@ def main():
     appfiles = find_dependency_files(appPath)
 
     if 1 > len(appfiles):
-        return outputError('Gathering dependency definition file(s)',
+        return output_error('Gathering dependency definition file(s)',
                            "I was unable to locate any dependency definition files")
 
     doCommit = False
@@ -99,7 +99,7 @@ def main():
         output, error = procUpdate.communicate()
 
         if 0 != procUpdate.returncode:
-            return outputError(updaters[dependencyFile]['command'], error)
+            return output_error(updaters[dependencyFile]['command'], error)
         # now let's see if we have updates
         output = error = None
         logging.info("Seeing if there are any updates to commit.")
@@ -124,7 +124,7 @@ def main():
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, error = procAdd.communicate()
         if 0 != procAdd.returncode:
-            return outputError('git add', error)
+            return output_error('git add', error)
         else:
             output = error = None
             gitCommitMsg += '\nAdded updated {}'.format(lockFileLocation)
@@ -137,7 +137,7 @@ def main():
         output, error = procCommit.communicate()
 
         if 0 != procCommit.returncode:
-            return outputError('git commit', error)
+            return output_error('git commit', error)
         else:
             logging.info("Changes successfully committed.")
             return True

--- a/autoupdate.py
+++ b/autoupdate.py
@@ -58,8 +58,19 @@ def main():
             toUpdate = list(set(filenames) & set(updaters.keys()))
 
             if appFile in filenames and 0 < len(toUpdate):
-                # dirpath is the full path to the file, and we only want the relative path
-                updateFiles += list(map(lambda file: os.path.join(dirpath.replace(path + '/', ''), file), toUpdate))
+                # dirpath is the full path to the file, and we only want the relative path. if the two are equal, we
+                # dont even need it
+                if dirpath == path:
+                    dirpath = ''
+                else:
+                    # otherwise we just want the relative bit
+                    # full path location: /mnt/source/app
+                    # path to composer.json: /mnt/source/app/drupal
+                    # We only want to record `drupal`
+                    # note, to add a cross-os-compatible ending directory slash, you path.join the path with empty. :shrug:
+                    dirpath.replace(os.path.join(dirpath, ''), '')
+
+                updateFiles += list(map(lambda file: os.path.join(dirpath, file), toUpdate))
 
         return updateFiles
 

--- a/autoupdate.py
+++ b/autoupdate.py
@@ -83,7 +83,7 @@ def main():
 
     if 1 > len(appfiles):
         return output_error('Gathering dependency definition file(s)',
-                           "I was unable to locate any dependency definition files")
+                            "I was unable to locate any dependency definition files")
 
     doCommit = False
 
@@ -93,7 +93,8 @@ def main():
         logging.info("Found a {} file...".format(dependencyFile))
         logging.info("Running {}".format(updaters[dependencyFile]['command']))
         # run the update process
-        procUpdate = subprocess.Popen(updaters[dependencyFile]['command'], shell=True, cwd=os.path.join(appPath, dependencyFilePath),
+        procUpdate = subprocess.Popen(updaters[dependencyFile]['command'], shell=True,
+                                      cwd=os.path.join(appPath, dependencyFilePath),
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)
         output, error = procUpdate.communicate()


### PR DESCRIPTION
**TL;DR** - adds support for multiapp projects that contain more than one application, each with their own dependency management (DM) system (e.g. gatsby + drupal where we need to update gatsby via yarn and drupal via composer) 

**Adds**
- Version number to better track which version is in use in a project's source operation
- subfunction `find_dependency_files()` to walk through project directory to find all instances of DM files and their *relative* locations, returns list
- default of `cwd()` to call for env var `PLATFORM_SOURCE_DIR`
- support to record each updated dependency management lock file in commit message

**Updates**
- .platform.app.yaml file name to a variable in case we need to change later
- directory path determination to make sure we're only including relative paths to our DM files
- renames method `outputError()` to `output_error()` to conform to PEP8

