### PR TITLE
Bug/12 pipenv update user

### DIFF
--- a/psh_utility.py
+++ b/psh_utility.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from psh_logging import outputError
 
-SOURCE_OP_TOOLS_VERSION = '0.2.5'
+SOURCE_OP_TOOLS_VERSION = '0.2.6'
 PSH_COMMON_MESSAGES = {
     'psh_cli': {
         'event': 'Checking for the Platform.sh CLI tool',


### PR DESCRIPTION
Fixes #12 
Prepends  `export PIP_USER=0` before running `pipenv update` if we're updating a Pipfile.