### PR TITLE
refactors how PM updated files are handled

### DIFF
--- a/autoupdate.py
+++ b/autoupdate.py
@@ -92,35 +92,18 @@ def main():
             logging.info("No updates available, nothing to commit. Exiting...")
             return True
 
-        updatedFiles = []
-
         possibleUpdates = updaters[dependencyFile]['lock'].split()
         for updatedFile in possibleUpdates:
             if updatedFile in procStatus['message']:
-                updatedFiles.append(updatedFile)
-
-        if 1 > len(updatedFiles):
-            # @todo _something_ updated, but it wasn't anything we *expected*. Should we do anything else besides
-            # provide a message an exit?
-            logging.info("Something updated but nothing we were expecting.")
-            logging.info(procStatus['message'])
-            logging.info("Exiting...")
-            return True
-
-        # one more, just need to add the file(s)
-        # we don't really care about the path if it's in the current directory
-        for toAdd in updatedFiles:
-            lockPath = lockFileLocation = procAdd = None
-            lockPath = (dependencyFilePath, '')[dependencyFilePath == './']
-            lockFileLocation = os.path.join(dependencyFilePath, toAdd)
-            logging.info("Updates are available, adding {}...".format(lockFileLocation))
-            procAdd = runCommand('git add {}'.format(lockFileLocation), appPath)
-
-            if not procAdd['result']:
-                return outputError('git add', procAdd['message'])
-            else:
-                gitCommitMsg += '\nAdded updated {}'.format(lockFileLocation)
-                doCommit = True
+                lockFileLocation = procAdd = None
+                lockFileLocation = os.path.join(dependencyFilePath, updatedFile)
+                logging.info("Updates are available, adding {}...".format(lockFileLocation))
+                procAdd = runCommand('git add {}'.format(lockFileLocation), appPath)
+                if not procAdd['result']:
+                    return outputError('git add', procAdd['message'])
+                else:
+                    gitCommitMsg += '\nAdded updated {}'.format(lockFileLocation)
+                    doCommit = True
 
     if doCommit:
         cmd = 'git commit -m "{}"'.format(gitCommitMsg)

--- a/psh_utility.py
+++ b/psh_utility.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from psh_logging import outputError
 
-SOURCE_OP_TOOLS_VERSION = '0.3.1'
+SOURCE_OP_TOOLS_VERSION = '0.3.2'
 PSH_COMMON_MESSAGES = {
     'psh_cli': {
         'event': 'Checking for the Platform.sh CLI tool',


### PR DESCRIPTION
Closes #30 

- adds a second file to the list of files that might be updated in an update process when using yarn as a package manager
- refactors the section that processes the git status to see if 1 or more of our possible PM files have updated